### PR TITLE
Fix interrupt signals on unix

### DIFF
--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -219,3 +219,4 @@ async fn setup_sighandler() -> io::Result<()> {
         }
     }
 }
+

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -219,4 +219,3 @@ async fn setup_sighandler() -> io::Result<()> {
         }
     }
 }
-


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
The old version was only able to capture `interrupt` ignoring `hangup` and `terminate`

## Testing
Killed pumpkin process with all signals and compared old and new version

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
